### PR TITLE
Allow the use of alternative methods to get record

### DIFF
--- a/src/DispatchListener.php
+++ b/src/DispatchListener.php
@@ -71,7 +71,8 @@ class DispatchListener implements EventListenerInterface
                         Inflector::tableize($methodParamClass->getShortName())
                     );
 
-                    $requestParams[$i] = $table->get($requestParam);
+                    $tableGetMethod = empty($table->paramConverterGetMethod) ? 'get' : $table->paramConverterGetMethod;
+                    $requestParams[$i] = $table->$tableGetMethod($requestParam);
                 } elseif (!empty($methodParamClass) && $methodParamClass->getName() === DateTime::class) {
                     $requestParams[$i] = new DateTime($requestParam);
                 } elseif (!empty($methodParamType)) {

--- a/tests/App/Controller/AltUsersController.php
+++ b/tests/App/Controller/AltUsersController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace ParamConverter\Test\App\Controller;
+
+use Cake\Controller\Controller;
+use ParamConverter\Test\App\Model\Entity\AltUser;
+
+class AltUsersController extends Controller
+{
+    public function withEntity(AltUser $entity): void
+    {
+    }
+}

--- a/tests/App/Model/Entity/AltUser.php
+++ b/tests/App/Model/Entity/AltUser.php
@@ -1,0 +1,9 @@
+<?php
+
+namespace ParamConverter\Test\App\Model\Entity;
+
+use Cake\ORM\Entity;
+
+class AltUser extends Entity
+{
+}

--- a/tests/App/Model/Table/AltUsersTable.php
+++ b/tests/App/Model/Table/AltUsersTable.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace ParamConverter\Test\App\Model\Table;
+
+use Cake\ORM\Table;
+
+class AltUsersTable extends Table
+{
+    public $paramConverterGetMethod = 'altGet';
+
+    public function altGet($id) {
+        $altUser = $this->newEntity();
+        $altUser->set('name', 'AltUserName');
+        return $altUser;
+    }
+}

--- a/tests/Fixture/AltUsersFixture.php
+++ b/tests/Fixture/AltUsersFixture.php
@@ -7,6 +7,6 @@ use Cake\TestSuite\Fixture\TestFixture;
  * UsersFixture
  *
  */
-class UsersFixture extends \Cake\Test\Fixture\UsersFixture
+class AltUsersFixture extends TestFixture
 {
 }

--- a/tests/Fixture/AltUsersFixture.php
+++ b/tests/Fixture/AltUsersFixture.php
@@ -1,0 +1,12 @@
+<?php
+namespace ParamConverter\Test\Fixture;
+
+use Cake\TestSuite\Fixture\TestFixture;
+
+/**
+ * UsersFixture
+ *
+ */
+class UsersFixture extends \Cake\Test\Fixture\UsersFixture
+{
+}

--- a/tests/TestCase/DispatchListenerTest.php
+++ b/tests/TestCase/DispatchListenerTest.php
@@ -10,6 +10,7 @@ use Cake\ORM\TableRegistry;
 use Cake\TestSuite\TestCase;
 use DateTime;
 use ParamConverter\DispatchListener;
+use ParamConverter\Test\App\Controller\AltUsersController;
 use ParamConverter\Test\App\Controller\UsersController;
 use ParamConverter\Test\App\Model\Table\UsersTable;
 
@@ -84,6 +85,24 @@ class DispatchListenerTest extends TestCase
         /** @var ServerRequest $updatedRequest */
         $updatedRequest = $event->getData('request');
         $this->assertTrue($updatedRequest->getParam('pass.0') instanceof EntityInterface);
+    }
+
+    public function testAlternateGetMethod(): void
+    {
+        $event = new Event('beforeEvent');
+        $event->setData('controller', new AltUsersController());
+
+        $request = (new ServerRequest())
+            ->withParam('pass', ["00000000-0000-0000-0000-000000000001"])
+            ->withParam('action', 'withEntity');
+        $response = new Response();
+
+        $listener = new DispatchListener();
+        $listener->beforeDispatch($event, $request, $response);
+
+        /** @var ServerRequest $updatedRequest */
+        $updatedRequest = $event->getData('request');
+        $this->assertEquals($updatedRequest->getParam('pass.0')->name, 'AltUserName');
     }
 
     public function testActionNoParams(): void


### PR DESCRIPTION
This PR would allow a different table methods to be used to get the record, if the paramConverterGetMethod property is defined in a Table.

```
class AppointmentsTable extends Table
{

    public $paramConverterGetMethod = 'getCached';
    function getCached($id)
        {
            // a more efficient way to get the record, or add contain options
        }
    ....
}
```