### PR TITLE
Param converter interface

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,8 @@
 # Param Converter
 
-[...]
+CakePHP v3.x plugin for converting request parameters to objects. These objects replace the original parameters before dispatching the controller action and hence they can be injected as controller method arguments.
+
+Heavily inspired by [Symfony ParamConverter](https://symfony.com/doc/current/bundles/SensioFrameworkExtraBundle/annotations/converters.html)
 
 ## Install
 
@@ -18,7 +20,29 @@ bin/cake plugin load ParamConverter
 
 ## Usage
 
-[...]
+Adjustments on application level are only necessary if you need to remove or / add new param converters.
+
+### Configuration
+
+By default, the plugin provides and registers two converters that can be used to convert request parameters to DateTime and Entity instances.
+Converters can be removed / added by adjusting the following configuration:
+
+``` php
+<?php
+// config/param_converter.php
+return [
+    'ParamConverter' => [
+        'converters' => [
+            \ParamConverter\EntityParamConverter::class,
+            \ParamConverter\DateTimeParamConverter::class,
+        ]
+    ]
+];
+```
+
+### Creating a converter
+
+All converters must implement the `ParamConverterInterface`.
 
 ## Security
 

--- a/config/bootstrap.php
+++ b/config/bootstrap.php
@@ -1,6 +1,9 @@
 <?php
 
+use Cake\Core\Configure;
 use Cake\Event\EventManager;
 use ParamConverter\DispatchListener;
+
+Configure::load('ParamConverter.param_converter');
 
 EventManager::instance()->on(new DispatchListener());

--- a/config/param_converter.php
+++ b/config/param_converter.php
@@ -1,0 +1,9 @@
+<?php
+return [
+    'ParamConverter' => [
+        'converters' => [
+            \ParamConverter\EntityParamConverter::class,
+            \ParamConverter\DateTimeParamConverter::class,
+        ]
+    ]
+];

--- a/src/DateTimeParamConverter.php
+++ b/src/DateTimeParamConverter.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace ParamConverter;
+
+use DateTime;
+
+/**
+ * Class DateTimeParamConverter
+ *
+ * Param Converter for DateTime class
+ *
+ * @package ParamConverter
+ */
+class DateTimeParamConverter implements ParamConverterInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function supports(string $class): bool
+    {
+        return $class === DateTime::class;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function convertTo(string $value, string $class)
+    {
+        return new DateTime($value);
+    }
+}

--- a/src/EntityParamConverter.php
+++ b/src/EntityParamConverter.php
@@ -1,0 +1,39 @@
+<?php
+
+namespace ParamConverter;
+
+use Cake\Core\App;
+use Cake\ORM\Entity;
+use Cake\ORM\TableRegistry;
+use Cake\Utility\Inflector;
+
+/**
+ * Class EntityParamConverter
+ *
+ * Param Converter for Entity classes
+ *
+ * @package ParamConverter
+ */
+class EntityParamConverter implements ParamConverterInterface
+{
+    /**
+     * @inheritDoc
+     */
+    public function supports(string $class): bool
+    {
+        return !empty($class) && is_subclass_of($class, Entity::class);
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function convertTo(string $value, string $class)
+    {
+        $table = App::shortName($class, 'Model/Entity');
+        $table = TableRegistry::getTableLocator()->get(
+            Inflector::tableize($table)
+        );
+
+        return $table->get($value);
+    }
+}

--- a/src/ParamConverterInterface.php
+++ b/src/ParamConverterInterface.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace ParamConverter;
+
+/**
+ * Interface ParamConverterInterface
+ *
+ * Converts request parameters to objects so that they can be injected to controller actions
+ *
+ * @package ParamConverter
+ */
+interface ParamConverterInterface
+{
+    /**
+     * Returns true only and only if the specified class is supported
+     *
+     * @param string $class Class to be checked
+     * @return bool
+     */
+    public function supports(string $class): bool;
+
+    /**
+     * @param string $value Value to be converted
+     * @param string $class Target class
+     * @return mixed
+     */
+    public function convertTo(string $value, string $class);
+}

--- a/src/ParamConverterManager.php
+++ b/src/ParamConverterManager.php
@@ -1,0 +1,97 @@
+<?php
+
+namespace ParamConverter;
+
+use Cake\Http\ServerRequest;
+use ReflectionMethod;
+
+class ParamConverterManager
+{
+    /**
+     * @var \ParamConverter\ParamConverterInterface[]
+     */
+    private $converters;
+
+    /**
+     * ParamConverterManager constructor.
+     * @param \ParamConverter\ParamConverterInterface[] $paramConverters List of converters
+     */
+    public function __construct(array $paramConverters)
+    {
+        foreach ($paramConverters as $paramConverter) {
+            $this->add($paramConverter);
+        }
+    }
+
+    /**
+     * Add the specified converter
+     *
+     * @param \ParamConverter\ParamConverterInterface $paramConverter Param Converter to be add
+     * @return void
+     */
+    public function add(ParamConverterInterface $paramConverter): void
+    {
+        $this->converters[] = $paramConverter;
+    }
+
+    /**
+     * Returns all the registered param converters
+     *
+     * @return \ParamConverter\ParamConverterInterface[]
+     */
+    public function all(): array
+    {
+        return $this->converters;
+    }
+
+    /**
+     * Applies all the registered converters to the specified request
+     *
+     * @param \Cake\Http\ServerRequest $request Request to be updated (replace params with objects)
+     * @param string $controller Controller name
+     * @param string $action action name
+     * @return \Cake\Http\ServerRequest
+     * @throws \ReflectionException
+     */
+    public function apply(ServerRequest $request, string $controller, string $action): ServerRequest
+    {
+        $method = new ReflectionMethod($controller, $action);
+        $methodParams = $method->getParameters();
+        $requestParams = $request->getParam('pass');
+
+        $stopAt = min(count($methodParams), count($requestParams));
+        for ($i = 0; $i < $stopAt; $i++) {
+            $methodParam = $methodParams[$i];
+            $requestParam = $requestParams[$i];
+
+            $methodParamClass = $methodParam->getClass();
+            if (!empty($methodParamClass)) {
+                $requestParams[$i] = $this->convertParam($requestParam, $methodParamClass->getName());
+            }
+
+            $methodParamType = $methodParam->getType();
+            if (!empty($methodParamType) && $methodParamType->isBuiltin()) {
+                settype($requestParam, $methodParamType->getName());
+                $requestParams[$i] = $requestParam;
+            }
+        }
+
+        return $request->withParam('pass', $requestParams);
+    }
+
+    /**
+     * Converts the specified string value to the specified class
+     *
+     * @param string $value Raw value to be converted to a class
+     * @param string $class Target class
+     * @return mixed
+     */
+    private function convertParam(string $value, string $class)
+    {
+        foreach ($this->all() as $converter) {
+            if ($converter->supports($class)) {
+                return $converter->convertTo($value, $class);
+            }
+        }
+    }
+}

--- a/tests/TestCase/DispatchListenerTest.php
+++ b/tests/TestCase/DispatchListenerTest.php
@@ -133,8 +133,8 @@ class DispatchListenerTest extends TestCase
         $response = new Response();
 
         $listener = new DispatchListener();
-        $listener->beforeDispatch($event, $request, $response);
 
-        $this->assertEmpty($event->getData('request'));
+        $this->expectException(\ReflectionException::class);
+        $listener->beforeDispatch($event, $request, $response);
     }
 }


### PR DESCRIPTION
Introduces ParamConverter interface.

The plugin includes two implementations for 1) DateTime and 2) Entity classes. New implementations can be defined on application level. 

Converters can be defined in configuration as per below:

``` php
return [
    'ParamConverter' => [
        'converters' => [
            \ParamConverter\EntityParamConverter::class,
            \ParamConverter\DateTimeParamConverter::class,
        ]
    ]
];
```